### PR TITLE
fix(docker): Two versions are pushed on latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
             fclairamb/ci-info
             ghcr.io/fclairamb/ci-info
           flavor: |
-            suffix=${{ matrix.type }}
+            suffix=${{ matrix.type != '' && format('-{0}', matrix.type) || '' }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
           images: fclairamb/ci-info
           flavor: |
             suffix=${{ matrix.type }}
+            suffixLatest=${{ matrix.type }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -69,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./Dockerfile${{ matrix.type == '' && '' || format('.{0}', matrix.type) }}
+          file: ./Dockerfile${{ matrix.type != '' && format('.{0}', matrix.type) || '' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: ${{ github.repository == 'fclairamb/ci-info' }}
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Build docker images
 
 on:
   push:
-    branches: # At least when doing some tests
-     - "**"
+    #branches: # At least when doing some tests
+    # - "**"
     tags:
       - "v*.*.*"
   # pull_request:
@@ -40,7 +40,7 @@ jobs:
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=ref,event=tag,pattern=latest${{ matrix.type != '' && format('-{0}', matrix.type) || '' }}
+            type=semver,pattern=latest${{ matrix.type != '' && format('-{0}', matrix.type) || '' }}
             type=ref,event=branch
             type=ref,event=pr
       - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,12 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v4
         with:
           images: fclairamb/ci-info
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=semver,pattern=alpine
+            type=ref,event=pr
       - name: Docker meta (alpine)
         id: docker_meta_alpine
         uses: crazy-max/ghaction-docker-meta@v4
@@ -36,6 +42,12 @@ jobs:
           images: fclairamb/ci-info
           flavor: |
             suffix=-alpine
+          tags: |
+              type=semver,pattern=v{{version}}
+              type=semver,pattern=v{{major}}.{{minor}}
+              type=semver,pattern=v{{major}}
+              type=semver,pattern=alpine
+              type=ref,event=pr
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,10 @@ on:
   # pull_request:
 
 jobs:
-  multi-registries:
+  build-and-push:
+    strategy:
+      matrix:
+        type: ["", "alpine"]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -24,30 +27,19 @@ jobs:
         run: |
           go build -v ./...
           ./ci-info
-      - name: Docker meta (scratch)
+      - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v4
         with:
           images: fclairamb/ci-info
+          flavor: |
+            suffix=${{ matrix.type }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
             type=semver,pattern=alpine
             type=ref,event=pr
-      - name: Docker meta (alpine)
-        id: docker_meta_alpine
-        uses: crazy-max/ghaction-docker-meta@v4
-        with:
-          images: fclairamb/ci-info
-          flavor: |
-            suffix=-alpine
-          tags: |
-              type=semver,pattern=v{{version}}
-              type=semver,pattern=v{{major}}.{{minor}}
-              type=semver,pattern=v{{major}}
-              type=semver,pattern=alpine
-              type=ref,event=pr
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -56,7 +48,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.type }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to DockerHub
@@ -76,21 +68,16 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile${{ matrix.type == '' && '' || '.' + matrix.type }}
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: ${{ github.repository == 'fclairamb/ci-info' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Build and push (alpine)
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ./Dockerfile.alpine
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
-          push: ${{ github.repository == 'fclairamb/ci-info' }}
-          tags: ${{ steps.docker_meta_alpine.outputs.tags }}
-          labels: ${{ steps.docker_meta_alpine.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+
+  build-and-push-status:
+      needs: build-and-push
+      runs-on: ubuntu-20.04
+      steps:
+        - run: echo 'All good'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,7 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
             type=semver,pattern=alpine
+            type=ref,event=branch
             type=ref,event=pr
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./Dockerfile${{ matrix.type == '' && '' || '.' + matrix.type }}
+          file: ./Dockerfile${{ matrix.type == '' && '' || format('.{0}', matrix.type) }}
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: ${{ github.repository == 'fclairamb/ci-info' }}
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Build docker images
 
 on:
   push:
-    # branches: # At least when doing some tests
-    #  - "**"
+    branches: # At least when doing some tests
+     - "**"
     tags:
       - "v*.*.*"
   # pull_request:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,17 +29,18 @@ jobs:
           ./ci-info
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v4
+        uses: docker/metadata-action@v4
         with:
-          images: fclairamb/ci-info
+          images: |
+            fclairamb/ci-info
+            ghcr.io/fclairamb/ci-info
           flavor: |
             suffix=${{ matrix.type }}
-            suffixLatest=${{ matrix.type }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=semver,pattern=alpine
+            type=ref,event=tag,pattern=latest${{ matrix.type != '' && format('-{0}', matrix.type) || '' }}
             type=ref,event=branch
             type=ref,event=pr
       - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,7 @@ jobs:
             ghcr.io/fclairamb/ci-info
           flavor: |
             suffix=${{ matrix.type != '' && format('-{0}', matrix.type) || '' }}
+            latest=false
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}


### PR DESCRIPTION
- Adding a `latest-alpine` instead of overwriting `latest` at each build
- Building the standard and alpine versions in parallel
- Pushing major.minor and major tags